### PR TITLE
rename configure to create_router

### DIFF
--- a/idom_router/__init__.py
+++ b/idom_router/__init__.py
@@ -3,8 +3,8 @@ __version__ = "0.0.1"
 
 from .router import (
     Route,
-    RoutesConstructor,
-    configure,
+    RouterConstructor,
+    create_router,
     link,
     use_location,
     use_params,
@@ -12,10 +12,10 @@ from .router import (
 )
 
 __all__ = [
-    "configure",
+    "create_router",
     "link",
     "Route",
-    "RoutesConstructor",
+    "RouterConstructor",
     "use_location",
     "use_params",
     "use_query",

--- a/idom_router/router.py
+++ b/idom_router/router.py
@@ -19,14 +19,14 @@ except ImportError:  # pragma: no cover
     from typing_extensions import Protocol  # type: ignore
 
 
-class RoutesConstructor(Protocol):
+class RouterConstructor(Protocol):
     def __call__(self, *routes: Route) -> ComponentType:
         ...
 
 
-def configure(
+def create_router(
     implementation: BackendImplementation[Any] | Callable[[], Location]
-) -> RoutesConstructor:
+) -> RouterConstructor:
     if isinstance(implementation, BackendImplementation):
         use_location = implementation.use_location
     elif callable(implementation):
@@ -38,7 +38,7 @@ def configure(
         )
 
     @component
-    def routes(*routes: Route) -> ComponentType | None:
+    def router(*routes: Route) -> ComponentType | None:
         initial_location = use_location()
         location, set_location = use_state(initial_location)
         compiled_routes = use_memo(
@@ -58,7 +58,7 @@ def configure(
                 )
         return None
 
-    return routes
+    return router
 
 
 @dataclass


### PR DESCRIPTION
This better aligns with the `create_context` function since `create_router` similarly returns a component constructor.